### PR TITLE
Patch version placeholder in teliod

### DIFF
--- a/net/nordvpn/Makefile
+++ b/net/nordvpn/Makefile
@@ -34,9 +34,16 @@ define Package/nordvpn/description
 	NordVPN is the gateway to a secure and private access to the internet.
 endef
 
+BINFILE := $(PKG_BUILD_DIR)/target/$(RUSTC_TARGET_ARCH)/release/teliod
+
 define Build/Compile
 	$(info RUSTC_TARGET_ARCH=$(RUSTC_TARGET_ARCH))	
+	$(info PKG_BUILD_DIR=$(PKG_BUILD_DIR))
+	$(info CARGO_PKG_VARS=$(CARGO_PKG_VARS))
+
 	cd $(PKG_BUILD_DIR) && $(CARGO_PKG_VARS) BYPASS_LLT_SECRETS=1 cargo build -p teliod --release --target $(RUSTC_TARGET_ARCH)
+	
+	$(CURDIR)/../$(PKG_NAME)/version_placeholder_fix.py "$(BINFILE)" "$(PKG_VERSION)+openwrt"
 endef
 
 define Package/nordvpn/install

--- a/net/nordvpn/version_placeholder_fix.py
+++ b/net/nordvpn/version_placeholder_fix.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import sys
+import re
+
+if len(sys.argv) != 3:
+    sys.exit(f"Usage: {sys.argv[0]} <file> <version>")
+
+teliod_path, version = sys.argv[1], sys.argv[2]
+
+with open(teliod_path, "rb") as f:
+    data = f.read()
+
+m = re.search(br"VERSION_PLACEHOLDER@+\x00", data)
+if not m:
+    sys.exit("ERROR: version placeholder not found")
+
+start, end = m.span()
+field_len = end - start
+max_len = field_len - 1  # subtract the final NUL
+
+print(f"Replacing version placeholder in {teliod_path} with '{version}'")
+print(f"Field length: {field_len} bytes, max_length: {max_len} bytes")
+
+if len(version) > max_len:
+    sys.exit(f"ERROR: version too long (max {max_len} bytes)")
+
+# Construct replacement string that's padded with NULs
+repl = version.encode() + b"\x00"
+repl = repl.ljust(field_len, b"\x00")
+
+newdata = data[:start] + repl + data[end:]
+
+with open(teliod_path, "wb") as f:
+    f.write(newdata)


### PR DESCRIPTION
Libtelio has a version placeholder which when promoting the build is then patched(string is replaced in binary).

As a result, when building "teliod" binary it contains the placeholder of the version.

In order to interfere with libtelio as little as possible, the version patching is done explicitly in here, OpenWRT Makefile.

When producing build from this PR, this is the log output:
```
...
2025-08-28T08:57:04.167117Z  INFO telio::device: 498: Created libtelio instance 1.0.0+openwrt, dev
...
```